### PR TITLE
Fix string formatting in activityTitle to use single quotes for environment retrieval

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -38,7 +38,7 @@ async def post_webhook(name: str, url: str, message: str, event_data: dict) -> b
                 "summary": message,
                 "sections": [
                     {
-                        "activityTitle": f"{message}, Environment: {event_data.get("environment")}",
+                        "activityTitle": f"{message}, Environment: {event_data.get('environment')}",
                         "activitySubtitle": f"{name} ({VERSION}) - {action}",
                         "activityImage": WEBUI_FAVICON_URL,
                         "facts": facts,


### PR DESCRIPTION
Fix string formatting in activityTitle to use single quotes for environment retrieval